### PR TITLE
Fix misleading error messages for unsupported attributes and blocks

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -289,6 +289,7 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 					"Function calls not allowed",
 					"Unsupported argument",
 					"Unsupported attribute",
+					"Unsupported block type",
 				}
 
 				if slices.Contains(errorSummaries, err.Summary) {

--- a/dag.go
+++ b/dag.go
@@ -288,6 +288,7 @@ func createCallback(c *Config, wf WalkCallback) func(v dag.Vertex) (diags dag.Di
 					"Invalid nested splat expressions",
 					"Function calls not allowed",
 					"Unsupported argument",
+					"Unsupported attribute",
 				}
 
 				if slices.Contains(errorSummaries, err.Summary) {


### PR DESCRIPTION
## Problem

When HCL encounters configuration errors like unknown fields or blocks in wrong locations, hclconfig was producing misleading error messages that made debugging very difficult.

### Before this fix:
- Unknown field (e.g., `content` instead of `file`): 
  ```
  unable to create resource "resource.page.customize_homepage": read /path/to/lab: is a directory
  ```
- Block in wrong location (e.g., `check` at task level instead of condition level): Silent success ❌

### After this fix:
- Unknown field: 
  ```
  Missing required argument; The argument "file" is required, but no definition was found.
  ```
- Block in wrong location:
  ```
  Unsupported block type; Blocks of type "check" are not expected here.
  ```

## Root Cause

The issue was in `dag.go` lines 267-291. The `errorSummaries` list was missing two critical HCL error types:
- `"Unsupported attribute"` - for unknown fields
- `"Unsupported block type"` - for blocks placed at incorrect levels

This caused these errors to be treated as warnings instead of errors, leading to them being swallowed or converted to misleading messages.

## Solution

Added the missing error summaries to the `errorSummaries` list:
```go
errorSummaries := []string{
    // ... existing entries ...
    "Unsupported argument",
    "Unsupported attribute",      // ← Added
    "Unsupported block type",     // ← Added
}
```

## Testing

Verified the fix works by:
1. Building CLI with local hclconfig changes
2. Testing with invalid field name - now shows clear "Missing required argument" error
3. Testing with block in wrong location - now shows clear "Unsupported block type" error
4. Both scenarios previously showed misleading "is a directory" error or passed silently

## Impact

This significantly improves the debugging experience for users writing HCL configuration by providing clear, actionable error messages instead of confusing generic errors.

Discovered while testing the getting started guide where `content` was incorrectly used instead of `file` for page resources, and `check` blocks were placed at task level instead of condition level.